### PR TITLE
Add take button and update empire inventory

### DIFF
--- a/32e23.html
+++ b/32e23.html
@@ -982,7 +982,7 @@
                         </div>
                         
                                                   <div class="gunweb-section">
-                              <h3>Empire Guns</h3>
+                              <h3>Gun Marketplace</h3>
                               <div id="gun-marketplace-list"></div>
                           </div>
                     </div>
@@ -8279,7 +8279,7 @@
                                 <div style="font-size: 0.9em; opacity: 0.7;">Type: ${gun.type || 'Unknown'}</div>
                                 <div style="font-size: 0.9em; opacity: 0.7;">Buy Price: $${(gun.buyPrice || 0).toLocaleString()}</div>
                                 <div style="color: #4ade80;">Sell Price: $${(gun.sellPrice || 0).toLocaleString()}</div>
-                                <div style="color: #fbbf24;">Total Value: $${((gun.sellPrice || 0) * (gun.quantity || 1)).toLocaleString()}</div>
+                                <div style="color: #fbbf24;">Reserved Value: $${((gun.sellPrice || 0) * (gun.reservedForEmpire || 0)).toLocaleString()}</div>
                             </div>
                             <div style="display: flex; flex-direction: column; gap: 0.5rem; align-items: flex-end;">
                                 <button onclick="game.moveGunToSell('${gunName}')" class="btn-secondary" style="background: #3b82f6; color: white;">Reduce Reserved</button>
@@ -8626,7 +8626,7 @@
                 const gun = this.gameData.gunInventory[gunName];
                 if (!gun) return;
 
-                const available = (gun.quantity || 1);
+                const available = Math.max(0, (gun.quantity || 1) - (gun.reservedForEmpire || 0));
                 const modalContent = `
                     <div class="quantity-modal">
                         <h3>Take Guns to Empire</h3>
@@ -8662,7 +8662,14 @@
                 if (typeof gun.quantity === 'undefined' || gun.quantity === null) gun.quantity = 1;
                 if (typeof gun.reservedForEmpire === 'undefined' || gun.reservedForEmpire === null) gun.reservedForEmpire = 0;
 
-                const takeQty = Math.max(1, Math.min(quantity, gun.quantity));
+                const sellableLeft = Math.max(0, (gun.quantity || 1) - (gun.reservedForEmpire || 0));
+                const takeQty = Math.max(0, Math.min(quantity, sellableLeft));
+                if (takeQty <= 0) {
+                    this.showNotification(`No available ${gunName} to reserve`, 'error');
+                    this.hideModal();
+                    return;
+                }
+
                 gun.reservedForEmpire += takeQty;
                 if (gun.reservedForEmpire > gun.quantity) gun.reservedForEmpire = gun.quantity;
 

--- a/32e23.html
+++ b/32e23.html
@@ -977,7 +977,7 @@
                         </div>
                         
                         <div class="gunweb-section">
-                            <h3>Your Gun Inventory</h3>
+                            <h3>Empire Guns</h3>
                             <div id="gun-inventory-list"></div>
                         </div>
                         
@@ -2540,7 +2540,6 @@
                     this.hideModal();
                 });
             }
-
             buyDrug(drugName, quality, price, quantity = 1, customName = '') {
                 const totalCost = price * quantity;
                 if (this.gameData.cashBalance >= totalCost) {
@@ -4282,7 +4281,6 @@
                 const bar = document.querySelector(`[data-laundering-id="${launderingId}"]`);
                 if (bar) bar.remove();
             }
-
             showNotification(message, type = 'info') {
                 document.querySelectorAll('.notification').forEach(n => n.remove());
                 
@@ -5512,7 +5510,6 @@
                     this.hideModal();
                 });
             }
-
             showPropertyBillModal(propertyIndex) {
                 const property = this.gameData.properties[propertyIndex];
                 const billData = this.gameData.propertyBills[propertyIndex] || { amount: 0 };
@@ -6145,7 +6142,6 @@
                     this.showNotification('Failed to export save data!', 'error');
                 }
             }
-
             importSave() {
                 navigator.clipboard.readText().then(text => {
                     try {
@@ -6769,7 +6765,6 @@
                     this.showEmpireManagerModal();
                 }); 
             }
-
             editEmpireName(oldName) {
                 const newName = prompt('Enter new empire name:', oldName);
                 if (newName && newName.trim() && newName !== oldName) {
@@ -7688,6 +7683,12 @@
                         if (typeof gun.quantity === 'undefined' || gun.quantity === null) {
                             gun.quantity = 1;
                         }
+                        if (typeof gun.reservedForEmpire === 'undefined' || gun.reservedForEmpire === null || gun.reservedForEmpire < 0) {
+                            gun.reservedForEmpire = 0;
+                        }
+                        if (gun.reservedForEmpire > gun.quantity) {
+                            gun.reservedForEmpire = gun.quantity;
+                        }
                     });
                 }
             }
@@ -8012,10 +8013,18 @@
                 if (cartelOffer.status !== 'pending') return;
                 
                 const gun = this.gameData.gunInventory[cartelOffer.name];
-                if (!gun || (gun.quantity || 1) < cartelOffer.quantity) {
+                if (!gun) {
                     cartelOffer.status = 'failed';
                     this.saveGame();
                     this.showNotification(`Cartel deal failed - insufficient ${cartelOffer.name}`, 'error');
+                    return;
+                }
+                const reserved = gun.reservedForEmpire || 0;
+                const sellable = (gun.quantity || 1) - reserved;
+                if (sellable < cartelOffer.quantity) {
+                    cartelOffer.status = 'failed';
+                    this.saveGame();
+                    this.showNotification(`Cartel deal failed - reserved ${reserved} of ${cartelOffer.name}. Reduce reserved to proceed.`, 'error');
                     return;
                 }
 
@@ -8049,7 +8058,6 @@
                 this.renderGunWebPage();
                 this.showNotification(`Cartel gun deal completed! Earned $${totalEarnings.toLocaleString()}!`, 'success');
             }
-
             renderGunBuyList() {
                 const container = document.getElementById('gun-buy-list');
                 if (!container) return;
@@ -8217,10 +8225,12 @@
                                 <div class="drug-name">${gunName}${gunData.quantity > 1 ? ` x${gunData.quantity}` : ''}</div>
                                 <div style="font-size: 0.9em; opacity: 0.7;">Type: ${gunData.type}</div>
                                 <div style="color: #4ade80;">$${gunData.sellPrice.toLocaleString()} <span class="money-type">(Cash)</span></div>
+                                <div style=\"font-size: 0.85em; opacity: 0.8;\">Reserved: ${gunData.reservedForEmpire || 0} | Available: ${(gunData.quantity || 1) - (gunData.reservedForEmpire || 0)}</div>
                             </div>
                             <div style="display: flex; flex-direction: column; gap: 0.5rem; align-items: flex-end;">
                                 <button onclick="game.sellGun('${gunName}')" class="action-btn">Sell</button>
                                 <button onclick="game.editGunPrice('${gunName}')" class="btn-secondary" style="font-size: 0.8em;">Change Price</button>
+                                <button onclick="game.showTakeGunModal('${gunName}')" class="btn-secondary" style="font-size: 0.8em;">Take</button>
                                 ${this.gameData.inCartel ? `<button onclick="game.showCartelGunOffer('${gunName}')" class="btn-secondary" style="font-size: 0.8em;">Cartel Offer</button>` : ''}
                             </div>
                         </div>
@@ -8234,8 +8244,8 @@
                 if (!container) return;
 
                 // Calculate total empire guns value
-                const totalEmpireGuns = Object.values(this.gameData.gunInventory || {}).reduce((sum, gun) => sum + (gun.quantity || 1), 0);
-                const totalEmpireGunsValue = Object.values(this.gameData.gunInventory || {}).reduce((sum, gun) => sum + ((gun.sellPrice || 0) * (gun.quantity || 1)), 0);
+                const totalEmpireGuns = Object.values(this.gameData.gunInventory || {}).reduce((sum, gun) => sum + (gun.reservedForEmpire || 0), 0);
+                const totalEmpireGunsValue = Object.values(this.gameData.gunInventory || {}).reduce((sum, gun) => sum + ((gun.sellPrice || 0) * (gun.reservedForEmpire || 0)), 0);
 
                 container.innerHTML = '';
                 
@@ -8265,14 +8275,14 @@
                     gunDiv.innerHTML = `
                         <div style="display: flex; justify-content: space-between; align-items: center; height: 100%;">
                             <div style="flex: 1;">
-                                <div class="drug-name">${gunName} x${gun.quantity || 1}</div>
+                                <div class="drug-name">${gunName} x${gun.reservedForEmpire || 0}</div>
                                 <div style="font-size: 0.9em; opacity: 0.7;">Type: ${gun.type || 'Unknown'}</div>
                                 <div style="font-size: 0.9em; opacity: 0.7;">Buy Price: $${(gun.buyPrice || 0).toLocaleString()}</div>
                                 <div style="color: #4ade80;">Sell Price: $${(gun.sellPrice || 0).toLocaleString()}</div>
                                 <div style="color: #fbbf24;">Total Value: $${((gun.sellPrice || 0) * (gun.quantity || 1)).toLocaleString()}</div>
                             </div>
                             <div style="display: flex; flex-direction: column; gap: 0.5rem; align-items: flex-end;">
-                                <button onclick="game.moveGunToSell('${gunName}')" class="btn-secondary" style="background: #3b82f6; color: white;">Back to Sell</button>
+                                <button onclick="game.moveGunToSell('${gunName}')" class="btn-secondary" style="background: #3b82f6; color: white;">Reduce Reserved</button>
                                 <button onclick="game.destroyEmpireGun('${gunName}')" class="btn-secondary" style="background: #ef4444; color: white;">Destroy</button>
                             </div>
                         </div>
@@ -8285,10 +8295,18 @@
                 const gun = this.gameData.gunInventory[gunName];
                 if (!gun) return;
 
-                // Move the gun to the sell list (this will be handled by the existing sell system)
-                // The gun is already in gunInventory, so it will appear in the sell guns section
-                this.showNotification(`Gun "${gunName}" is now available for sale`, 'success');
-                this.renderGunWebPage(); // Refresh the page to show changes
+                if (typeof gun.reservedForEmpire === 'undefined' || gun.reservedForEmpire === null) gun.reservedForEmpire = 0;
+                if (gun.reservedForEmpire <= 0) {
+                    this.showNotification(`No reserved ${gunName} to reduce`, 'error');
+                    return;
+                }
+
+                gun.reservedForEmpire -= 1;
+                if (gun.reservedForEmpire < 0) gun.reservedForEmpire = 0;
+
+                this.saveGame();
+                this.showNotification(`Reduced reserved ${gunName} by 1`, 'success');
+                this.renderGunWebPage();
             }
 
             destroyEmpireGun(gunName) {
@@ -8300,13 +8318,15 @@
                     <div class="quantity-modal">
                         <h3>Destroy Empire Gun</h3>
                         <div class="quantity-input-section">
-                            <p>Are you sure you want to destroy <strong>${gunName}</strong>?</p>
+                            <p>Are you sure you want to destroy reserved <strong>${gunName}</strong>?</p>
                             <p style="color: #ef4444;">This action cannot be undone!</p>
-                            <p>Quantity: ${gun.quantity || 1}</p>
-                            <p>Value: $${((gun.sellPrice || 0) * (gun.quantity || 1)).toLocaleString()}</p>
+                            <p>Reserved Quantity: ${gun.reservedForEmpire || 0}</p>
+                            <p>Reserved Value: $${(((gun.sellPrice || 0) * (gun.reservedForEmpire || 0))||0).toLocaleString()}</p>
+                            <label for="destroy-reserved-qty">Quantity to destroy:</label>
+                            <input type="number" id="destroy-reserved-qty" value="${Math.min(1, gun.reservedForEmpire || 0)}" min="1" max="${gun.reservedForEmpire || 0}">
                         </div>
                         <div class="modal-actions">
-                            <button onclick="game.confirmDestroyEmpireGun('${gunName}')" class="btn-secondary" style="background: #ef4444; color: white;">Destroy Gun</button>
+                            <button onclick="game.confirmDestroyEmpireGun('${gunName}')" class="btn-secondary" style="background: #ef4444; color: white;">Destroy</button>
                             <button id="modal-cancel" class="btn-secondary">Cancel</button>
                         </div>
                     </div>
@@ -8324,13 +8344,20 @@
                 const gun = this.gameData.gunInventory[gunName];
                 if (!gun) return;
 
-                // Remove the gun from inventory
-                delete this.gameData.gunInventory[gunName];
+                const input = document.getElementById('destroy-reserved-qty');
+                const qty = Math.max(1, Math.min(parseInt(input?.value) || 1, gun.reservedForEmpire || 0));
+                const before = gun.reservedForEmpire || 0;
+                gun.reservedForEmpire = Math.max(0, before - qty);
+
+                // If everything is unreserved and quantity is 0, remove entry
+                if ((gun.quantity || 0) <= 0 && gun.reservedForEmpire === 0) {
+                    delete this.gameData.gunInventory[gunName];
+                }
                 
                 this.saveGame();
-                this.showNotification(`Destroyed "${gunName}" from empire inventory`, 'success');
+                this.showNotification(`Destroyed ${qty} reserved ${gunName}`, 'success');
                 this.hideModal();
-                this.renderGunWebPage(); // Refresh the page to show changes
+                this.renderGunWebPage();
             }
 
             renderGunMarketplace() {
@@ -8529,15 +8556,30 @@
                 const gun = this.gameData.gunInventory[gunName];
                 if (!gun) return;
 
+                if (typeof gun.quantity === 'undefined' || gun.quantity === null) gun.quantity = 1;
+                if (typeof gun.reservedForEmpire === 'undefined' || gun.reservedForEmpire === null) gun.reservedForEmpire = 0;
+
+                const sellable = gun.quantity - gun.reservedForEmpire;
+                if (sellable <= 0) {
+                    this.showNotification('All of these are reserved for your empire. Reduce reserved amount before selling.', 'error');
+                    return;
+                }
+
                 const sellPrice = gun.sellPrice;
-                                this.gameData.cashBalance += sellPrice;
-                
-                if (gun.quantity > 1) {
-                    // Decrease quantity if more than 1
+                this.gameData.cashBalance += sellPrice;
+
+                if (sellable > 1) {
+                    // Decrease quantity by 1 while preserving reservations
                     gun.quantity -= 1;
                 } else {
-                    // Remove gun if quantity is 1
-                    delete this.gameData.gunInventory[gunName];
+                    // sellable is 1, so if reservedForEmpire > 0, we must ensure not to drop below reserved
+                    gun.quantity -= 1;
+                    if (gun.quantity < gun.reservedForEmpire) {
+                        gun.reservedForEmpire = gun.quantity;
+                    }
+                    if (gun.quantity <= 0) {
+                        delete this.gameData.gunInventory[gunName];
+                    }
                 }
                 
                 // Track gun sales in totalEarnings for networth calculation
@@ -8578,9 +8620,59 @@
                 document.getElementById('modal-cancel').addEventListener('click', () => {
                     this.hideModal();
                 });
+                        }
+ 
+            showTakeGunModal(gunName) {
+                const gun = this.gameData.gunInventory[gunName];
+                if (!gun) return;
+
+                const available = (gun.quantity || 1);
+                const modalContent = `
+                    <div class="quantity-modal">
+                        <h3>Take Guns to Empire</h3>
+                        <div class="quantity-input-section">
+                            <p>How many <strong>${gunName}</strong> do you want to take for your empire?</p>
+                            <input type="number" id="take-gun-quantity" placeholder="Quantity" min="1" max="${available}" value="${Math.min(available, 1)}">
+                            <div style="font-size: 0.9em; opacity: 0.7; margin-top: 0.5rem;">Available to take: ${available}</div>
+                        </div>
+                        <div class="modal-actions">
+                            <button id="confirm-take-gun" class="btn-primary">Take</button>
+                            <button id="modal-cancel" class="btn-secondary">Cancel</button>
+                        </div>
+                    </div>
+                `;
+
+                document.getElementById('modal-overlay').innerHTML = modalContent;
+                document.getElementById('modal-overlay').classList.remove('hidden');
+
+                document.getElementById('confirm-take-gun').addEventListener('click', () => {
+                    const qty = Math.max(1, Math.min(parseInt(document.getElementById('take-gun-quantity').value) || 1, available));
+                    this.confirmTakeGun(gunName, qty);
+                });
+
+                document.getElementById('modal-cancel').addEventListener('click', () => {
+                    this.hideModal();
+                });
             }
 
-            saveGunPrice(gunName) {
+            confirmTakeGun(gunName, quantity) {
+                const gun = this.gameData.gunInventory[gunName];
+                if (!gun) return;
+
+                if (typeof gun.quantity === 'undefined' || gun.quantity === null) gun.quantity = 1;
+                if (typeof gun.reservedForEmpire === 'undefined' || gun.reservedForEmpire === null) gun.reservedForEmpire = 0;
+
+                const takeQty = Math.max(1, Math.min(quantity, gun.quantity));
+                gun.reservedForEmpire += takeQty;
+                if (gun.reservedForEmpire > gun.quantity) gun.reservedForEmpire = gun.quantity;
+
+                this.saveGame();
+                this.hideModal();
+                this.renderGunWebPage();
+                this.showNotification(`Reserved ${takeQty}x ${gunName} for your empire`, 'success');
+            }
+
+             saveGunPrice(gunName) {
                 const newPrice = parseInt(document.getElementById('gun-price').value) || 0;
                 if (newPrice > 0 && this.gameData.gunInventory[gunName]) {
                     this.gameData.gunInventory[gunName].sellPrice = newPrice;
@@ -8592,7 +8684,6 @@
                     this.showNotification('Invalid price!', 'error');
                 }
             }
-
             renderSpendPage() {
                 const page = document.getElementById('spend-page');
                 if (!page) return;
@@ -8620,8 +8711,8 @@
                 const totalCarPayoff = Math.floor((this.gameData.cars||[]).reduce((s,c)=>s+((c.price||0)*0.75),0));
                 carsSection.innerHTML = `
                     <h3>Owned Cars</h3>
-                    <div style="opacity:0.8; font-size:0.95em; margin-bottom:0.5rem;">Total Value: $${totalCarValue.toLocaleString()} | Outstanding Bills: $${totalCarBills.toLocaleString()} | Total Payoff: $${totalCarPayoff.toLocaleString()} <button onclick="game.showPayAllCarBillsModal()" class="btn-secondary" style="margin-left:0.5rem; padding:0.25rem 0.5rem; font-size:0.85em;">Pay All Bills</button> <button onclick="game.showPayoffAllCarsModal()" class="btn-secondary" style="margin-left:0.5rem; padding:0.25rem 0.5rem; font-size:0.85em;">Pay Off All</button></div>
-                    <div id="owned-cars-list"></div>
+                    <div style=\"opacity:0.8; font-size:0.95em; margin-bottom:0.5rem;\">Total Value: $${totalCarValue.toLocaleString()} | Outstanding Bills: $${totalCarBills.toLocaleString()} | Total Payoff: $${totalCarPayoff.toLocaleString()} <button onclick=\"game.showPayAllCarBillsModal()\" class=\"btn-secondary\" style=\"margin-left:0.5rem; padding:0.25rem 0.5rem; font-size:0.85em;\">Pay All Bills</button> <button onclick=\"game.showPayoffAllCarsModal()\" class=\"btn-secondary\" style=\"margin-left:0.5rem; padding:0.25rem 0.5rem; font-size:0.85em;\">Pay Off All</button></div>
+                    <div id=\"owned-cars-list\"></div>
                 `;
 
                 // Owned Properties Section
@@ -8633,8 +8724,8 @@
                 const totalPropPayoff = Math.floor((this.gameData.properties||[]).reduce((s,p)=>s+((p.price||0)*0.75),0));
                 propertiesSection.innerHTML = `
                     <h3>Owned Properties</h3>
-                    <div style="opacity:0.8; font-size:0.95em; margin-bottom:0.5rem;">Total Value: $${totalPropValue.toLocaleString()} | Outstanding Bills: $${totalPropBills.toLocaleString()} | Total Payoff: $${totalPropPayoff.toLocaleString()} <button onclick="game.showPayAllPropertyBillsModal()" class="btn-secondary" style="margin-left:0.5rem; padding:0.25rem 0.5rem; font-size:0.85em;">Pay All Bills</button> <button onclick="game.showPayoffAllPropertiesModal()" class="btn-secondary" style="margin-left:0.5rem; padding:0.25rem 0.5rem; font-size:0.85em;">Pay Off All</button></div>
-                    <div id="owned-properties-list"></div>
+                    <div style=\"opacity:0.8; font-size:0.95em; margin-bottom:0.5rem;\">Total Value: $${totalPropValue.toLocaleString()} | Outstanding Bills: $${totalPropBills.toLocaleString()} | Total Payoff: $${totalPropPayoff.toLocaleString()} <button onclick=\"game.showPayAllPropertyBillsModal()\" class=\"btn-secondary\" style=\"margin-left:0.5rem; padding:0.25rem 0.5rem; font-size:0.85em;\">Pay All Bills</button> <button onclick=\"game.showPayoffAllPropertiesModal()\" class=\"btn-secondary\" style=\"margin-left:0.5rem; padding:0.25rem 0.5rem; font-size:0.85em;\">Pay Off All</button></div>
+                    <div id=\"owned-properties-list\"></div>
                 `;
 
                 if (categories && categories.parentNode) {
@@ -9244,7 +9335,6 @@
                 this.hideModal();
                 this.renderSpendPage();
             }
-
             retrieveProductsFromCar(carIndex) {
                 const car = this.gameData.cars[carIndex];
                 if (!car || !this.gameData.carInventory || !this.gameData.carInventory[carIndex] || Object.keys(this.gameData.carInventory[carIndex]).length === 0) {
@@ -9418,26 +9508,26 @@
                 Object.entries(inventory).forEach(([key, item]) => {
                     const totalValue = item.quantity * item.sellPrice;
                     productsHTML += `
-                        <div style=\"border-bottom: 1px solid #333; padding: 0.5rem 0; display:flex; justify-content:space-between; align-items:center;\">
+                        <div style="border-bottom: 1px solid #333; padding: 0.5rem 0; display:flex; justify-content:space-between; align-items:center;">
                             <div>
-                                <div style=\"font-weight:600;\">${item.customName || item.drug} (${item.quality})</div>
-                                <div style=\"font-size:0.9em; opacity:0.7;\">Quantity: ${item.quantity}x</div>
-                                <div style=\"font-size:0.9em; opacity:0.7;\">Value: $${totalValue.toLocaleString()}</div>
+                                <div style="font-weight:600;">${item.customName || item.drug} (${item.quality})</div>
+                                <div style="font-size:0.9em; opacity:0.7;">Quantity: ${item.quantity}x</div>
+                                <div style="font-size:0.9em; opacity:0.7;">Value: $${totalValue.toLocaleString()}</div>
                             </div>
-                            <div style=\"display:flex; gap:0.5rem; align-items:center;\">
-                                <input type=\"number\" id=\"retrieve-from-prop-${key.replace(/[^a-zA-Z0-9]/g,'')}\" value=\"1\" min=\"1\" max=\"${item.quantity}\" style=\"width:80px; background:#2a2a2a; border:1px solid #444; color:white; padding:0.25rem;\">
-                                <button onclick=\"game.retrieveSpecificProductFromProperty(${propertyIndex}, '${key}')\" class=\"action-btn\">Retrieve</button>
+                            <div style="display:flex; gap:0.5rem; align-items:center;">
+                                <input type="number" id="retrieve-from-prop-${key.replace(/[^a-zA-Z0-9]/g,'')}" value="1" min="1" max="${item.quantity}" style="width:80px; background:#2a2a2a; border:1px solid #444; color:white; padding:0.25rem;">
+                                <button onclick="game.retrieveSpecificProductFromProperty(${propertyIndex}, '${key}')" class="action-btn">Retrieve</button>
                             </div>
                         </div>
                     `;
                 });
                 productsHTML += '</div>';
                 const modalContent = `
-                    <div class=\"quantity-modal\">
+                    <div class="quantity-modal">
                         <h3>Retrieve Products from ${property.name}</h3>
                         ${productsHTML}
-                        <div class=\"modal-actions\" style=\"margin-top: 1rem;\">
-                            <button id=\"modal-cancel\" class=\"btn-secondary\">Cancel</button>
+                        <div class="modal-actions" style="margin-top: 1rem;">
+                            <button id="modal-cancel" class="btn-secondary">Cancel</button>
                         </div>
                     </div>
                 `;


### PR DESCRIPTION
Adds a 'Take' button to reserve guns for the empire and renames 'Your Gun Inventory' to 'Empire Guns'.

---
<a href="https://cursor.com/background-agent?bcId=bc-6f5896ff-a17f-4246-9f53-2757c4b7f85c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6f5896ff-a17f-4246-9f53-2757c4b7f85c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

